### PR TITLE
Add command whitelist option to zoo.cfg.j2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ zookeeper_distro_file: "apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz"
 zookeeper_distro_url: "https://archive.apache.org/dist/zookeeper/zookeeper-{{ zookeeper_version }}/{{ zookeeper_distro_file }}"
 zookeeper_user_name: zookeeper
 zookeeper_group_name: zookeeper
+zookeeper_cmd_whitelist: ""
 zookeeper_create_user: yes
 zookeeper_create_group: yes
 zookeeper_base_dir: /opt/zookeeper
@@ -16,7 +17,6 @@ zookeeper_log_threshold: INFO
 zookeeper_log_max_file_size: 256MB
 zookeeper_log_max_backup_index: 20
 zookeeper_data_dir: /var/lib/zookeeper
-zookeeper_extra_settings: []
 zookeeper_id: 1
 zookeeper_tick_time: 2000
 zookeeper_init_limit: 10

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ zookeeper_log_threshold: INFO
 zookeeper_log_max_file_size: 256MB
 zookeeper_log_max_backup_index: 20
 zookeeper_data_dir: /var/lib/zookeeper
+zookeeper_extra_settings: []
 zookeeper_id: 1
 zookeeper_tick_time: 2000
 zookeeper_init_limit: 10

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -27,16 +27,8 @@ autopurge.snapRetainCount={{ zookeeper_autopurge_snap_retain_count }}
 # Set to "0" to disable auto purge feature
 autopurge.purgeInterval={{ zookeeper_autopurge_purge_interval }}
 
-# For any other settings not covered here, you can define
-#
-# zookeeper_extra_settings:
-# - varName: varValue
-# - otherVarName: otherVarValue
-#
-# Where the var names should match what is detailed in the Zookeeper docs.
-{% for var_name, var_value in zookeeper_extra_settings.items() %}
-{{ var_name }}={{ var_value }}
-{% endfor %}
+# Whitelist Zookeeper commands so that they can be executed from a remote host
+4lw.commands.whitelist={{ zookeeper_cmd_whitelist }}
 
 ## Metrics Providers
 #

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -27,6 +27,17 @@ autopurge.snapRetainCount={{ zookeeper_autopurge_snap_retain_count }}
 # Set to "0" to disable auto purge feature
 autopurge.purgeInterval={{ zookeeper_autopurge_purge_interval }}
 
+# For any other settings not covered here, you can define
+#
+# zookeeper_extra_settings:
+# - varName: varValue
+# - otherVarName: otherVarValue
+#
+# Where the var names should match what is detailed in the Zookeeper docs.
+{% for var_name, var_value in zookeeper_extra_settings.items() %}
+{{ var_name }}={{ var_value }}
+{% endfor %}
+
 ## Metrics Providers
 #
 # https://prometheus.io Metrics Exporter


### PR DESCRIPTION
Thanks for this ansible role, it is great. For our use case we would like to set other zookeeper config variables (for instance currently the whitelist). I thought that giving some freedom for adding more config vars could help. Unless I'm missing the expected way of adding more config variables in the current role.